### PR TITLE
V0.52 Update CathClassificationProvider source URL to use HTTPS

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -42,4 +42,4 @@
   9-Dec-2024    V0.49 Update Azure pipelines to use latest macOS, Ubuntu, and python 3.10
   8-Dec-2025    V0.50 Switch from setuptools to hatch build system and update pipelines to Python 3.13
   6-Jan-2026    V0.51 Update ScopClassificationProvider source URL
- 28-Jan-2026    V0.52 Update ScopClassificationProvider source URL
+ 28-Jan-2026    V0.52 Update CathClassificationProvider source URL to use HTTPS

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -42,3 +42,4 @@
   9-Dec-2024    V0.49 Update Azure pipelines to use latest macOS, Ubuntu, and python 3.10
   8-Dec-2025    V0.50 Switch from setuptools to hatch build system and update pipelines to Python 3.13
   6-Jan-2026    V0.51 Update ScopClassificationProvider source URL
+ 28-Jan-2026    V0.52 Update ScopClassificationProvider source URL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rcsb.utils.struct"
 description = "RCSB Python utility classes for accessing PDB primary structure data and features associated with these data"
-version = "0.51"
+version = "0.52"
 readme = "README.md"
 authors = [
     { name="John Westbrook", email="john.westbrook@rcsb.org" }

--- a/rcsb/utils/struct/CathClassificationProvider.py
+++ b/rcsb/utils/struct/CathClassificationProvider.py
@@ -5,6 +5,7 @@
 #  Updates:
 #   15-Jul-2021 jdw Update the constructor to common provider API conventions
 #   18-Jul-2023 dwp Resolve duplication issues with CATH residue range list
+#   28-Jan-2026 dwp Switch to HTTPS
 ##
 """
   Extract CATH domain assignments, term descriptions and CATH classification hierarchy
@@ -43,8 +44,8 @@ class CathClassificationProvider(StashableBase):
         super(CathClassificationProvider, self).__init__(self.__cachePath, [self.__dirName])
         #
         useCache = kwargs.get("useCache", True)
-        urlTarget = kwargs.get("cathTargetUrl", "http://download.cathdb.info/cath/releases/daily-release/newest")
-        urlFallbackTarget = kwargs.get("cathTargetUrl", "http://download.cathdb.info/cath/releases/daily-release/archive")
+        urlTarget = kwargs.get("cathTargetUrl", "https://download.cathdb.info/cath/releases/daily-release/newest")
+        urlFallbackTarget = kwargs.get("cathTargetUrl", "https://download.cathdb.info/cath/releases/daily-release/archive")
         # no trailing /
         urlBackupPath = kwargs.get("cathUrlBackupPath", "https://raw.githubusercontent.com/rcsb/py-rcsb_exdb_assets/master/fall_back/CATH")
         #


### PR DESCRIPTION
Update `CathClassificationProvider` source URL to use HTTPS